### PR TITLE
Slightly increase the size of the RJ45 socket hole in the case

### DIFF
--- a/case/cheapino-top-left.scad
+++ b/case/cheapino-top-left.scad
@@ -24,7 +24,7 @@ translate([0, 0, top_of_pcb]) diodes();
 
 // RJ45 socket
 color("cyan") {
-    translate([29.955, -10.3, 4.1])
+    translate([29.5, -10.3, 4.1])
     linear_extrude(10)
     square([30, 16]);
 

--- a/case/cheapino-top-right.scad
+++ b/case/cheapino-top-right.scad
@@ -23,7 +23,7 @@ mirror() {
 
     // RJ45 socket
     color("cyan") {
-        translate([29.955, -9.03, 4.1])
+        translate([29.5, -9.03, 4.1])
         linear_extrude(10)
         square([30, 16]);
 


### PR DESCRIPTION
Thanks again for both a fantastic keyboard design, and a case to go with it!

I noticed that the top-half of the case fits pretty tight if you don't position the RJ45 socket just right. While sanding the case a bit does allow it to fit, expanding the socket hole size along the x-axis by 0.45mm also made it fit cleanly without modification.
