### PR TITLE
Tweak case cutout sizes slightly

### DIFF
--- a/case/cheapino-top-left.scad
+++ b/case/cheapino-top-left.scad
@@ -11,7 +11,7 @@ translate([0,0,9.1])
 rotate([0,180,0])
 difference() {
   case();
-  linear_extrude(4.1) offset(delta=0.15) base();
+  linear_extrude(4.1) offset(delta=0.45) base();
 
   // For debug: comment out above 3 lines and comment in this
   //translate([0,0,4.1])

--- a/case/cheapino-top-right.scad
+++ b/case/cheapino-top-right.scad
@@ -10,7 +10,7 @@ include <modules.scad>
 mirror() {
   difference() {
     case();
-    linear_extrude(4.1) offset(delta=0.15) base();
+    linear_extrude(4.1) offset(delta=0.45) base();
 
     // holes and shape for debug
     // translate([0,0,4.1])

--- a/case/modules.scad
+++ b/case/modules.scad
@@ -102,7 +102,7 @@ module switch(bottom) {
 module diode() {
 color("#8c564b")
 linear_extrude(height=1.65)
-square([9.5, 1.6]);
+square([9.5, 1.8]);
 }
 
 module rdiode() {


### PR DESCRIPTION
After printing a few cases, I found that it fit pretty tight in two places:

* the diode slots
* the main cutout in the top halves

This PR very slightly increases the width of the diode slots in both sides, and increases the delta for the cutout in the top halves. I've printed these changes and found that it fit the pcb and bottom half very easily, and the warping that I was getting with the previous prints was much less present. The case still required a little bit of experimentation to find the right place for the rubber feet, but not nearly as much as before.
